### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       - 'VERSION'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- update workflow to include `contents: write` permission for pushing tags/releases

## Testing
- `bun test` *(fails: 16 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_685ed248dc7083238bedf98c8b76f61a